### PR TITLE
Remove artifact type name which is getting picked-up from plan file

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -181,15 +180,8 @@ func generateTargetArtifacts(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	plan := r.FormValue("plan")
 
-	re := regexp.MustCompile(`artifactType:\s*([^\s]+)`)
-	artifactTypematch := re.FindStringSubmatch(plan)
-	artifactType := ""
-	if len(artifactTypematch) > 1 {
-		artifactType = artifactTypematch[1]
-	}
-
 	t := time.Now()
-	artifactName := name + "_" + artifactType + "_" + strconv.FormatInt(t.Unix(), 10)
+	artifactName := name + "_" + strconv.FormatInt(t.Unix(), 10)
 	log.Infof("Artifact Name:%s", artifactName)
 
 	err := m2kapp.Translate(name, artifactName, plan)


### PR DESCRIPTION
Signed-off-by: Akash Nayak <akash19nayak@gmail.com>

<img width="666" alt="Screenshot 2020-12-03 at 9 05 15 PM" src="https://user-images.githubusercontent.com/14867323/101051278-4c41ea00-35ab-11eb-90ba-df9ad4d6f83b.png">

The "Yamls" in the `artifactName`  is getting picked-up from the `artifactType` name in the plan file. https://github.com/konveyor/move2kube-api/issues/31

<img width="912" alt="Screenshot 2020-12-03 at 8 50 45 PM" src="https://user-images.githubusercontent.com/14867323/101051091-1997f180-35ab-11eb-95d4-42d5c2576ce2.png">

<img width="790" alt="Screenshot 2020-12-03 at 9 52 46 PM" src="https://user-images.githubusercontent.com/14867323/101057272-e311a500-35b1-11eb-85f4-12c3f9c893ba.png">