### PR TITLE
fix: remove creation and uploading of release assets

### DIFF
--- a/.github/workflows/assignproject.yml
+++ b/.github/workflows/assignproject.yml
@@ -1,12 +1,14 @@
 name: Assign Project
+
 on:
   issues:
     types: [opened]
+
 jobs:
-  createCard:
+  create_card:
     runs-on: ubuntu-latest
     steps:
-      - name: Create project card
+      - name: create project card
         uses: peter-evans/create-or-update-project-card@v1
         with:
           token: ${{ secrets.MOVE2KUBE_PATOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,66 +2,61 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
-  build:
-    name: Build and Test
+  build_and_test:
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Build and Test 
-      run: make ci
-    - name: Test Coverage
-      run: make test-coverage
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v1
-    - uses: rtCamp/action-slack-notify@v2
-      if: failure()
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#BD3232'
-        SLACK_ICON: https://github.com/actions.png?size=48
-        SLACK_MESSAGE: 'Build failed in master'
-        SLACK_TITLE: Failed
-        SLACK_USERNAME: GitHubActions
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - uses: actions/checkout@v2
+      - run: make ci
+      - run: make test-coverage
+      - name: upload coverage
+        uses: codecov/codecov-action@v1
+      - if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: "#BD3232"
+          SLACK_ICON: https://github.com/actions.png?size=48
+          SLACK_MESSAGE: "Build failed in move2kube-api master"
+          SLACK_TITLE: Failed
+          SLACK_USERNAME: GitHubActions
 
-  image-build:
-    name: Image Build
+  image_build:
+    needs: [build_and_test]
+    name: Image build
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
-    - uses: actions/checkout@v2
-    - name: Pull latest image to reuse layers
-      run: |
-        docker pull quay.io/konveyor/move2kube-api:latest || true
-        docker pull quay.io/konveyor/move2kube-api-builder:latest || true
-    - name: Build and Push image to quay
-      run: |
-        echo "${{ secrets.QUAY_BOT_PASSWORD }}" | docker login --username "${{ secrets.QUAY_BOT_USERNAME }}" --password-stdin quay.io
-        make cbuild
-        make cpush
-    - name: Success Slack Notification
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_ICON: https://github.com/actions.png?size=48
-        SLACK_MESSAGE: 'Built and Pushed quay.io/konveyor/move2kube-api:latest'
-        SLACK_TITLE: Success
-        SLACK_USERNAME: GitHubActions
-    - name: Failure Slack Notification
-      uses: rtCamp/action-slack-notify@v2
-      if: failure()
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#BD3232'
-        SLACK_ICON: https://github.com/actions.png?size=48
-        SLACK_MESSAGE: 'Failed to build and push image quay.io/konveyor/move2kube-api:latest'
-        SLACK_TITLE: Failed
-        SLACK_USERNAME: GitHubActions
+      - uses: actions/checkout@v2
+      - name: Pull latest image to reuse layers
+        run: |
+          docker pull quay.io/konveyor/move2kube-api:latest || true
+          docker pull quay.io/konveyor/move2kube-api-builder:latest || true
+      - name: Build and Push image to quay
+        run: |
+          echo "${{ secrets.QUAY_BOT_PASSWORD }}" | docker login --username "${{ secrets.QUAY_BOT_USERNAME }}" --password-stdin quay.io
+          make cbuild
+          make cpush
+      - name: success slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_ICON: https://github.com/actions.png?size=48
+          SLACK_MESSAGE: "Built and pushed quay.io/konveyor/move2kube-api:latest"
+          SLACK_TITLE: Success
+          SLACK_USERNAME: GitHubActions
+      - if: failure()
+        name: failure slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: "#BD3232"
+          SLACK_ICON: https://github.com/actions.png?size=48
+          SLACK_MESSAGE: "Failed to build and push image quay.io/konveyor/move2kube-api:latest"
+          SLACK_TITLE: Failed
+          SLACK_USERNAME: GitHubActions

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -2,23 +2,18 @@ name: PR Build
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
-    name: Build and Test
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Build and Test 
-      run: make ci
-    - name: Test Coverage
-      run: make test-coverage
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v1
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - uses: actions/checkout@v2
+      - run: make ci
+      - run: make test-coverage
+      - name: upload coverage
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,6 @@ jobs:
         run: |
           npm install github-release-notes@v0.17.3 -g
           gren release --draft --prerelease --tags ${{ steps.only_tag.outputs.tag }} --username=${{ github.repository_owner }} --repo=${{ github.event.repository.name }} --token=${{ secrets.GITHUB_TOKEN }}
-      - run: make dist
-      - name: upload release assets
-        uses: HarikrishnanBalagopal/upload-release-action@v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          file: _dist/output/*
-          file_glob: true
-          overwrite: true
       - name: slack notification
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
The API server is meant to be consumed as part of
the UI. If it needs to be run standalone we provide
a container image. Don't see much benefit in providing
prebuilt binaries for now.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>