### PR TITLE
fix: Disable the timestamp from move2kube in the logs

### DIFF
--- a/internal/application/filesystem.go
+++ b/internal/application/filesystem.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,6 +51,8 @@ const (
 	m2kQAServerMetadataFile = "." + appNameShort + "qa"
 	m2kPlanOngoingFile      = "." + appNameShort + "plan"
 	apiServerPort           = 8080
+	timestampRegex          = `time="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"`
+	m2kString               = "Move2Kube"
 )
 
 // FileSystem implements the IApplication interface and manages the application data in a filesystem
@@ -312,8 +315,10 @@ func runPlan(appName string, debugMode bool) bool {
 	go func() {
 		for scannerStdout.Scan() {
 			text := scannerStdout.Text()
+			var re = regexp.MustCompile(timestampRegex)
+			updatedText := re.ReplaceAllString(text, m2kString)
 			if strings.TrimSpace(text) != "" {
-				outch <- text
+				outch <- updatedText
 			}
 		}
 		wg.Done()
@@ -324,8 +329,10 @@ func runPlan(appName string, debugMode bool) bool {
 	go func() {
 		for scannerStderr.Scan() {
 			text := scannerStderr.Text()
+			var re = regexp.MustCompile(timestampRegex)
+			updatedText := re.ReplaceAllString(text, m2kString)
 			if strings.TrimSpace(text) != "" {
-				outch <- text
+				outch <- updatedText
 			}
 		}
 		wg.Done()
@@ -483,8 +490,10 @@ func runTranslate(appName string, artifactpath string, translatech chan string, 
 	go func() {
 		for scannerStdout.Scan() {
 			text := scannerStdout.Text()
+			var re = regexp.MustCompile(timestampRegex)
+			updatedText := re.ReplaceAllString(text, m2kString)
 			if strings.TrimSpace(text) != "" {
-				outch <- text
+				outch <- updatedText
 			}
 		}
 		wg.Done()
@@ -495,8 +504,10 @@ func runTranslate(appName string, artifactpath string, translatech chan string, 
 	go func() {
 		for scannerStderr.Scan() {
 			text := scannerStderr.Text()
+			var re = regexp.MustCompile(timestampRegex)
+			updatedText := re.ReplaceAllString(text, m2kString)
 			if strings.TrimSpace(text) != "" {
-				outch <- text
+				outch <- updatedText
 			}
 		}
 		wg.Done()

--- a/internal/application/filesystem.go
+++ b/internal/application/filesystem.go
@@ -649,7 +649,9 @@ func (a *FileSystem) PostSolution(appName string, artifact string, solution stri
 			log.Error(err)
 			return err
 		}
-		log.Infof(string(body))
+		if string(body) != "" {
+			log.Infof(string(body))
+		}
 		return nil
 	}
 	urlstr := "http://" + metadatayaml.Node + ":" + strconv.Itoa(apiServerPort) + "/api/v1/applications/" + appName + "/targetartifacts/" + artifact + "/problems/current/solution"


### PR DESCRIPTION
The logs had two timestamps in a single line.
```
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"Planning Translation\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.DockerfileTranslator] Planning translation\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.DockerfileTranslator] Done\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.ComposeTranslator] Planning translation\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.ComposeTranslator] Done\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.CfManifestTranslator] Planning translation\""
move2kubeapi_1  | time="2021-01-05T08:08:09Z" level=info msg="time=\"2021-01-05T08:08:09Z\" level=info msg=\"[*source.CfManifestTranslator] Done\""
```

I have disabled the timestamp in the api.
```
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"Planning Translation\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.DockerfileTranslator] Planning translation\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.DockerfileTranslator] Done\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.ComposeTranslator] Planning translation\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.ComposeTranslator] Done\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.CfManifestTranslator] Planning translation\""
move2kubeapi_1  | level=info msg="time=\"2021-01-05T08:31:03Z\" level=info msg=\"[*source.CfManifestTranslator] Done\""
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>