### PR TITLE
fix: Invoke move2kube in verbose mode if move2kube-api is invoked in verbose mode

### DIFF
--- a/cmd/move2kubeapi/move2kubeapi.go
+++ b/cmd/move2kubeapi/move2kubeapi.go
@@ -21,13 +21,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/konveyor/move2kube-api/internal/application"
 	"github.com/konveyor/move2kube-api/internal/move2kubeapi"
 )
 
 var (
 	workspace string
 	port      int
-	verbose   bool
 )
 
 func main() {
@@ -42,14 +42,15 @@ func main() {
 For more information, visit https://konveyor.io/move2kube
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
-			if verbose {
+			if application.Verbose {
 				log.SetLevel(log.DebugLevel)
 			}
+			log.Debugf("Verbose output: %v", application.Verbose)
 			move2kubeapi.Serve(port)
 		},
 	}
 
-	apiCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	apiCmd.Flags().BoolVarP(&application.Verbose, "verbose", "v", false, "Enable verbose output")
 	apiCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port for the QA service. By default it chooses a random free port.")
 
 	if err := apiCmd.Execute(); err != nil {


### PR DESCRIPTION
Fixes- https://github.com/konveyor/move2kube-api/issues/65

Plan phase logs with api invoked in verbose mode
```
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"Planning Metadata\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.ClusterMDLoader] Planning metadata\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=debug msg="App name: langplat; level=debug msg=\"No of files with [.yml .yaml] ext identified : 0\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.ClusterMDLoader] Done\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.K8sFilesLoader] Planning metadata\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=debug msg="App name: langplat; level=debug msg=\"No of files with [.yml .yaml] ext identified : 0\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.K8sFilesLoader] Done\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.QACacheLoader] Planning metadata\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=debug msg="App name: langplat; level=debug msg=\"No of files with [.yml .yaml] ext identified : 0\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"[*metadata.QACacheLoader] Done\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"Metadata planning done\""
move2kubeapi_1  | time="2021-01-21T09:16:49Z" level=info msg="App name: langplat; level=info msg=\"Plan can be found at [/workspace/langplat/m2k.plan].\""
```

Translate phase logs with api invoked in verbose mode
```
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="QA engine to started for app langplat at http://localhost:39137"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"Failed to read the yaml file at path langplat/artifacts/langplat_1611220875/m2kqache.yaml Error: \\\"open langplat/artifacts/langplat_1611220875/m2kqache.yaml: no such file or directory\\\"\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=error msg="App name: langplat; Artifact name:langplat_1611220875; level=error msg=\"Unable to load cache : open langplat/artifacts/langplat_1611220875/m2kqache.yaml: no such file or directory\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=error msg="App name: langplat; Artifact name:langplat_1611220875; level=error msg=\"Ignoring engine *qaengine.CacheEngine due to error : open langplat/artifacts/langplat_1611220875/m2kqache.yaml: no such file or directory\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="App name: langplat; Artifact name:langplat_1611220875; level=info msg=\"Detected a plan file at path /workspace/langplat/artifacts/langplat_1611220875/m2k.plan. Will translate using this plan.\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="Translation started for application langplat with url http://localhost:39137"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"Translated artifacts will be written to /workspace/langplat/artifacts/langplat_1611220875/langplat\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="Getting question langplat for langplat_1611220875"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"Creating the cache file at path /workspace/langplat/artifacts/langplat_1611220875/langplat/m2kqacache.yaml\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="HostNames : localhost"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="HostNames : e4633eb0959a"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="Chosen hostname : e4633eb0959a"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=info msg="Getting question from http://localhost:39137/problems/current"
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"Looking for a problem fron HTTP REST service\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"Passing problem to HTTP REST QA Engine ID: 1, desc: Select all translation types that you are interested in:\""
move2kubeapi_1  | time="2021-01-21T09:21:15Z" level=debug msg="App name: langplat; Artifact name:langplat_1611220875; level=debug msg=\"QA Engine serves problem id: 1, desc: Select all translation types that you are interested in:\""
```
Signed-off-by: Akash Nayak <akash19nayak@gmail.com>