### PR TITLE
fix: multi arch build with buildkit always enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           docker pull quay.io/konveyor/move2kube-api-builder:latest || true
       - run: echo "${{ secrets.QUAY_BOT_PASSWORD }}" | docker login --username "${{ secrets.QUAY_BOT_USERNAME }}" --password-stdin quay.io
       - name: build image
-        run: VERSION='${{ steps.image_tag.outputs.tag }}' GO_VERSION='${{ steps.info.outputs.go_version }}' make cbuild
+        run: export DOCKER_BUILDKIT=1 && VERSION='${{ steps.image_tag.outputs.tag }}' GO_VERSION='${{ steps.info.outputs.go_version }}' make cbuild
       - name: push image to quay
         run: VERSION='${{ steps.image_tag.outputs.tag }}' make cpush
       - name: success slack notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           docker pull quay.io/konveyor/move2kube-api-builder:latest || true
       - run: echo "${{ secrets.QUAY_BOT_PASSWORD }}" | docker login --username "${{ secrets.QUAY_BOT_USERNAME }}" --password-stdin quay.io
       - name: build container image
-        run: VERSION='${{ github.event.inputs.tag }}' GO_VERSION='${{ steps.info.outputs.go_version }}' make cbuild
+        run: export DOCKER_BUILDKIT=1 && VERSION='${{ github.event.inputs.tag }}' GO_VERSION='${{ steps.info.outputs.go_version }}' make cbuild
       - name: push image to quay
         run: VERSION='${{ github.event.inputs.tag }}' make cpush
       - name: success slack notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 # Download Go.
 ARG GO_VERSION=1.18
-ARG TARGETARCH
-ARG TARGETOS
+ARG TARGETARCH=amd64
+ARG TARGETOS=linux
 RUN curl -o go.tgz "https://dl.google.com/go/go${GO_VERSION}.${TARGETOS}-${TARGETARCH}.tar.gz" \
     && tar -xzf go.tgz \
     && mv go /usr/local/ \

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ HAS_UPX    = $(shell command -v upx >/dev/null && echo true || echo false)
 
 GOGET     := cd / && GO111MODULE=on go install 
 
-export DOCKER_BUILDKIT := 1
-
 MULTI_ARCH_TARGET_PLATFORMS := linux/amd64,linux/arm64
 
 ifdef VERSION


### PR DESCRIPTION
Signed-off-by: Mehant Kammakomati <kmehant@gmail.com>

platform environment various `TARGETPLATFORM`, `TARGETOS`, `TARGETARCH` are only available when the `docker build` is run using `buildkit`. 

In this PR, 
* we are enabling buildkit for all our docker image builds
* Replaced `TARGETPLATFORM` with much useful `TARGETOS`, `TARGETARCH` environment variables

✅ Empirically tested on my fork's github workflow. 