### PR TITLE
fix: in a couple of places we were using the standard library for logging instead of logrus

### DIFF
--- a/cmd/main/move2kubeapi.go
+++ b/cmd/main/move2kubeapi.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"log"
 	"strings"
 
 	"github.com/konveyor/move2kube-api/cmd/main/umask"
@@ -120,10 +119,10 @@ func onInitialize() {
 	setupViper()
 	logLevel, err := logrus.ParseLevel(common.Config.LogLevel)
 	if err != nil {
-		log.Fatalf("the log level is invalid. Error: %q", err)
+		logrus.Fatalf("the log level is invalid. Error: %q", err)
 	}
 	if common.Config.AuthServerTimeout <= 0 {
-		log.Fatalf("the auth server timeout is invalid. Expected a positive integer. Actual: '%d'", common.Config.AuthServerTimeout)
+		logrus.Fatalf("the auth server timeout is invalid. Expected a positive integer. Actual: '%d'", common.Config.AuthServerTimeout)
 	}
 	logrus.SetLevel(logLevel)
 	logrus.Debugf("log level: %s", logLevel.String())

--- a/internal/move2kubeapi/move2kubeapi.go
+++ b/internal/move2kubeapi/move2kubeapi.go
@@ -19,7 +19,6 @@ package move2kubeapi
 import (
 	"fmt"
 	"io/fs"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -154,9 +153,9 @@ func Serve() error {
 		finfo, err := os.Stat(staticFilesDir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Fatalf("the static files directory %s does not exist.", staticFilesDir)
+				logrus.Fatalf("the static files directory %s does not exist.", staticFilesDir)
 			}
-			log.Fatalf("failed to stat the static files directory at path %s . Error: %q", staticFilesDir, err)
+			logrus.Fatalf("failed to stat the static files directory at path %s . Error: %q", staticFilesDir, err)
 		}
 		if !finfo.IsDir() {
 			return fmt.Errorf("the path %s points to a file. Expected a directory containing static files to be served", staticFilesDir)

--- a/internal/move2kubeapi/move2kubeapi.go
+++ b/internal/move2kubeapi/move2kubeapi.go
@@ -153,9 +153,9 @@ func Serve() error {
 		finfo, err := os.Stat(staticFilesDir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				logrus.Fatalf("the static files directory %s does not exist.", staticFilesDir)
+				return fmt.Errorf("the static files directory %s does not exist", staticFilesDir)
 			}
-			logrus.Fatalf("failed to stat the static files directory at path %s . Error: %q", staticFilesDir, err)
+			return fmt.Errorf("failed to stat the static files directory at path %s . Error: %q", staticFilesDir, err)
 		}
 		if !finfo.IsDir() {
 			return fmt.Errorf("the path %s points to a file. Expected a directory containing static files to be served", staticFilesDir)


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>