### PR TITLE
fix: Openapi get workspaces fixes

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -2359,6 +2359,39 @@
             "type": "string",
             "format": "date-time"
           },
+          "project_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "normalized_name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "description": {
             "type": "string",
             "description": "A description about the workspace.",


### PR DESCRIPTION
The openapi is not completed, this is an example output of my code:

```
$ --> curl http://localhost:8081/api/v1/workspaces | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   440  100   440    0     0   322k      0 --:--:-- --:--:-- --:--:--  429k
[
  {
    "id": "e7e905df-ed99-4430-804c-efa5bec94678",
    "name": "12313",
    "description": "123123",
    "timestamp": "2023-05-08T12:07:01.006582995Z",
    "project_ids": [
      "1e804dab-f516-460c-9ef5-a7b703958b3a"
    ],
    "inputs": {
      "001b0d9d-15ad-4855-a356-9bed3810a9b6": {
        "id": "001b0d9d-15ad-4855-a356-9bed3810a9b6",
        "name": "spring-helloworld-main.zip",
        "description": "",
        "timestamp": "2023-05-08T13:37:48.883095434Z",
        "type": "sources",
        "normalized_name": "spring-helloworld-main"
      }
    }
  }
]
```