### PR TITLE
fix: add missing fields on transform outputs

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1345,6 +1345,18 @@
                       "description": "ID of the new project output.",
                       "example": "proj-output-1234"
                     },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the project output."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the project output."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
                     "status": {
                       "type": "string",
                       "description": "The status of the transformation.",


### PR DESCRIPTION
The output is like this:

```
{"id":"cbf01f93-1e35-42be-a197-c63db8ae58f6","name":"cbf01f93-1e35-42be-a197-c63db8ae58f6","description":"","timestamp":"2023-05-20T10:44:50.798757172Z","status":"transforming"}
```