### PR TITLE
feat(api): add source and qa-skip as parameters for plan and outputs endpoints

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1091,6 +1091,16 @@
             "schema": {
               "$ref": "#/components/schemas/ID"
             }
+          },
+          {
+            "name": "remote-source",
+            "in": "query",
+            "description": "Remote source git URL from which get the source files.",
+            "required": false,
+            "example": "git+https://github.com/konveyor/move2kube",
+            "schema": {
+              "$ref": "#/components/schemas/RemoteSource"
+            }
           }
         ],
         "responses": {
@@ -1312,6 +1322,16 @@
             "example": "proj-1234",
             "schema": {
               "$ref": "#/components/schemas/ID"
+            }
+          },
+          {
+            "name": "skip-qa",
+            "in": "query",
+            "description": "Boolean to skip interactive QA.",
+            "required": false,
+            "example": "true",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -2294,6 +2314,12 @@
         "type": "string",
         "description": "A unique ID.",
         "example": "id-1234"
+      },
+      "RemoteSource": {
+        "pattern": "^git[+](https|ssh)://[a-zA-Z0-9]+([-.]{1}[a-zA-Z0-9]+)*[.][a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$",
+        "type": "string",
+        "description": "A git URL.",
+        "example": "git+https://github.com/konveyor/move2kube"
       },
       "Error": {
         "required": [

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -65,6 +65,8 @@ var (
 	AuthServerClient gocloak.GoCloak
 	// ID_REGEXP is the regexp used to check if a Id is valid
 	ID_REGEXP = regexp.MustCompile("^[a-zA-Z0-9-_]+$")
+	// REMOTE_SOURCE_REGEXP is the regexp used to check if a remote source is valid
+	REMOTE_SOURCE_REGEXP = regexp.MustCompile(`^git\+(https|ssh)://[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$`)
 	// INVALID_NAME_CHARS_REGEXP is the regexp used to replace invalid name characters with hyphen
 	INVALID_NAME_CHARS_REGEXP = regexp.MustCompile("[^a-z0-9-]")
 	// AUTHZ_HEADER is the authorization header

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -123,6 +123,11 @@ func IsValidId(id string) bool {
 	return ID_REGEXP.MatchString(id)
 }
 
+// IsRemoteSource returns true if the provided remoteSource is valid
+func IsRemoteSource(remoteSource string) bool {
+	return REMOTE_SOURCE_REGEXP.MatchString(remoteSource)
+}
+
 // IsStringPresent checks if a value is present in a slice
 func IsStringPresent(list []string, value string) bool {
 	for _, val := range list {

--- a/internal/filesystem/interface.go
+++ b/internal/filesystem/interface.go
@@ -40,12 +40,12 @@ type IFileSystem interface {
 	CreateProjectInput(workspaceId, projectId string, projInput types.ProjectInput, file io.Reader, isCommon bool) error
 	ReadProjectInput(workspaceId, projectId, projInputId string, isCommon bool) (projInput types.ProjectInput, file io.Reader, err error)
 	DeleteProjectInput(workspaceId, projectId, projInputId string, isCommon bool) error
-	StartPlanning(workspaceId, projectId string, debugMode bool) error
+	StartPlanning(workspaceId, projectId, remoteSource string, debugMode bool) error
 	ReadPlan(workspaceId, projectId string) (plan io.Reader, err error)
 	UpdatePlan(workspaceId, projectId string, plan io.Reader) error
 	DeletePlan(workspaceId, projectId string) error
-	StartTransformation(workspaceId, projectId string, projOutput types.ProjectOutput, plan io.Reader, debugMode bool) error
-	ResumeTransformation(workspaceId, projectId, projOutputId string, debugMode bool) error
+	StartTransformation(workspaceId, projectId string, projOutput types.ProjectOutput, plan io.Reader, debugMode, skipQA bool) error
+	ResumeTransformation(workspaceId, projectId, projOutputId string, debugMode, skipQA bool) error
 	ReadProjectOutput(workspaceId, projectId, projOutputId string) (projOutput types.ProjectOutput, file io.Reader, err error)
 	ReadProjectOutputGraph(workspaceId, projectId, projOutputId string) (projOutput types.ProjectOutput, file io.Reader, err error)
 	DeleteProjectOutput(workspaceId, projectId, projOutputId string) error

--- a/internal/move2kubeapi/handlers/handlers.go
+++ b/internal/move2kubeapi/handlers/handlers.go
@@ -30,6 +30,10 @@ import (
 )
 
 const (
+	// SKIP_QA_QUERY_PARAM is the name of the query parameter used for skipping QA
+	SKIP_QA_QUERY_PARAM = "skip-qa"
+	// REMOTE_SOURCE_QUERY_PARAM is the URL of the git remote to be used as source
+	REMOTE_SOURCE_QUERY_PARAM = "remote-source"
 	// DEBUG_QUERY_PARAM is the name of the query parameter used for debug mode
 	DEBUG_QUERY_PARAM = "debug"
 	// WORKSPACE_ID_ROUTE_VAR is the route variable that contains the workspace Id

--- a/internal/move2kubeapi/handlers/outputs.go
+++ b/internal/move2kubeapi/handlers/outputs.go
@@ -54,6 +54,7 @@ func HandleStartTransformation(w http.ResponseWriter, r *http.Request) {
 		planReader = nil
 	}
 	debugMode := r.URL.Query().Get(DEBUG_QUERY_PARAM) == "true"
+	skipQA := r.URL.Query().Get(SKIP_QA_QUERY_PARAM) == "true"
 	timestamp, _, err := common.GetTimestamp()
 	if err != nil {
 		logrus.Errorf("failed to get the timestamp. Error: %q", err)
@@ -65,7 +66,7 @@ func HandleStartTransformation(w http.ResponseWriter, r *http.Request) {
 	projOutput.Timestamp = timestamp
 	projOutput.Name = projOutput.Id // This isn't really used anywhere
 	projOutput.Status = types.ProjectOutputStatusInProgress
-	if err := m2kFS.StartTransformation(workspaceId, projectId, projOutput, planReader, debugMode); err != nil {
+	if err := m2kFS.StartTransformation(workspaceId, projectId, projOutput, planReader, debugMode, skipQA); err != nil {
 		logrus.Errorf("failed to start the transformation. Error: %q", err)
 		if notExErr, ok := err.(types.ErrorDoesNotExist); ok {
 			if notExErr.Id == "plan" {

--- a/internal/move2kubeapi/handlers/plan.go
+++ b/internal/move2kubeapi/handlers/plan.go
@@ -39,8 +39,14 @@ func HandleStartPlanning(w http.ResponseWriter, r *http.Request) {
 		sendErrorJSON(w, "invalid id", http.StatusBadRequest)
 		return
 	}
+	remoteSource := r.URL.Query().Get(REMOTE_SOURCE_QUERY_PARAM)
+	if remoteSource != "" && !common.IsRemoteSource(remoteSource) {
+		logrus.Errorf("invalid remote source format; not matching regexp %s. Actual: %s", common.REMOTE_SOURCE_REGEXP, remoteSource)
+		sendErrorJSON(w, "invalid remote source format", http.StatusBadRequest)
+		return
+	}
 	debugMode := r.URL.Query().Get(DEBUG_QUERY_PARAM) == "true"
-	if err := m2kFS.StartPlanning(workspaceId, projectId, debugMode); err != nil {
+	if err := m2kFS.StartPlanning(workspaceId, projectId, remoteSource, debugMode); err != nil {
 		logrus.Errorf("failed to start plan generation. Error: %q", err)
 		if _, ok := err.(types.ErrorDoesNotExist); ok {
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -346,6 +346,8 @@ func (e ErrorTokenUnverifiable) Error() string {
 type ProjectStatus string
 
 const (
+	// ProjectStatusRemoteInputSources indicates the project has a remlote git source
+	ProjectStatusRemoteInputSources ProjectStatus = "remote"
 	// ProjectStatusInputSources indicates the project has source folder uploaded
 	ProjectStatusInputSources ProjectStatus = "sources"
 	// ProjectStatusInputCustomizations indicates the project has customizations folder uploaded


### PR DESCRIPTION
In order to allow users to run Move2Kube with the API in a non-interactive mode, I added the `remote-source` query parameter in the `plan` endpoint and the `skip-qa` query parameter in the `outputs` endpoints.

`remote-source` is expected a git URL that will be used by the cmd.

`skip-qa` will set the the flag `qa-skip` to `true` when executing the transformation cmd.

This will allow CI pipeline to test the usage of M2K without any interaction or pre-configured file.

Needs https://github.com/konveyor/move2kube/pull/1109 to be merged as it fixes a missing default value for SSHKeys; when skipping the QA, it causes an error.