### PR TITLE
fix: Update Golang version in Makefile to prevent cbuild failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TARGETS     := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
 REGISTRYNS  := quay.io/konveyor
 SWAGGER_UI_VERSION := 3.52.3
 
-GO_VERSION   ?= $(shell go run ./scripts/detectgoversion/detect.go 2>/dev/null || printf '1.18')
+GO_VERSION   ?= $(shell go run ./scripts/detectgoversion/detect.go 2>/dev/null || printf '1.19')
 GOPATH        = $(shell go env GOPATH)
 GOX           = $(GOPATH)/bin/gox
 GOTEST        = ${GOPATH}/bin/gotest

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run using container from registry using `make crun`
 
 ## Setup
 
-1. Obtain a recent version of `golang`. Known to work with `1.18`.
+1. Obtain a recent version of `golang`. Known to work with `1.19`.
 1. Ensure `$GOPATH` is set. If it's not set:
    1. `mkdir ~/go`
    1. `export GOPATH=~/go`


### PR DESCRIPTION
Fixes: https://github.com/konveyor/move2kube-api/issues/160

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>