### PR TITLE
fix: respect DOCKER_HOST env var for better container runtime Support

### DIFF
--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -243,7 +243,11 @@ func (*FileSystem) GetSupportInfo() map[string]string {
 		}
 	}
 	info["docker"] = "docker socket is mounted"
-	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost == "" {
+		dockerHost = "/var/run/docker.socket"
+	}
+	if _, err := os.Stat(dockerHost); err != nil {
 		if os.IsNotExist(err) {
 			info["docker"] = "docker socket is not mounted"
 		} else {


### PR DESCRIPTION
DOCKER_HOST is now respected so the binary could be run again other
runtimes like podman, that exposes a compatible socket based api.
To use it export DOCKER_HOST=unix:///run/user/1000/podman/podman.sock
for running with a non root user.

If DOCKER_HOST is not exported then the default path
/var/run/docker.socket

Signed-off-by: Roy Golan <rgolan@redhat.com>
